### PR TITLE
Change to directory passed to out to be able to reference inputs and outputs

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -7,6 +7,8 @@ exec 1>&2 # redirect all output to stderr for logging
 
 . $(dirname $0)/common.sh
 
+cd $1
+
 payload=$(mktemp $TMPDIR/fly-resource-request.XXXXXX)
 cat > $payload <&0
 


### PR DESCRIPTION
This change enables you to refer to files using relative paths. Assuming an input `pipeline` that contains a `config.yml` you can therefore now do stuff like
```yaml
- put: fly
  params:
    command: set-pipeline
    options: -p my-pipeline -n -c pipeline/config.yml
```